### PR TITLE
chore: CLOUD-1372 add logging to scaffold relation and project cmds

### DIFF
--- a/internal/project/lib.go
+++ b/internal/project/lib.go
@@ -28,7 +28,7 @@ func (l *libDir) WriteChanges(fsys afero.Fs) error {
 	return nil
 }
 
-func (l *libDir) addRelation(contents string) error {
+func (l *libDir) addRelation(contents string) (string, error) {
 	return l.relations.addRelation(contents)
 }
 
@@ -101,14 +101,17 @@ func relationsFileFromDir(fsys afero.Fs, parent string) (*relationsFile, error) 
 	return r, nil
 }
 
-func (r *relationsFile) addRelation(contents string) error {
+func (r *relationsFile) addRelation(contents string) (string, error) {
 	rule, err := ast.ParseRule(contents)
 	if err != nil {
-		return err
+		return "", err
 	}
 	rule.Location.Row = r.lines + 1
 	r.module.Rules = append(r.module.Rules, rule)
-	return r.UpdateContents()
+	if err := r.UpdateContents(); err != nil {
+		return "", err
+	}
+	return r.Path(), nil
 }
 
 func (r *relationsFile) UpdateContents() error {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -98,7 +98,7 @@ func (p *Project) RuleSpecs() []*RuleSpec {
 
 // AddRelation adds the given relation rule to the relations library for this
 // project.
-func (p *Project) AddRelation(contents string) error {
+func (p *Project) AddRelation(contents string) (string, error) {
 	return p.libDir.addRelation(contents)
 }
 

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -233,14 +233,15 @@ func TestProjectWriteChanges(t *testing.T) {
 		assert.Empty(t, relations)
 
 		// Add a relation and write the changes to disk
-		err = p.AddRelation(`relation[info] {
+		relationsPath, err := p.AddRelation(`relation[info] {
 			info := snyk.relation_from_fields(
-                "aws_s3_bucket.logging",
-                {"aws_s3_bucket": ["id", "bucket"]},
-                {"aws_s3_bucket_logging": ["bucket"]},
-        	)
+				"aws_s3_bucket.logging",
+				{"aws_s3_bucket": ["id", "bucket"]},
+				{"aws_s3_bucket_logging": ["bucket"]},
+			)
 		}`)
 		assert.NoError(t, err)
+		assert.Equal(t, "new/lib/relations.rego", relationsPath)
 		err = p.WriteChanges()
 		assert.NoError(t, err)
 

--- a/internal/scaffold/forms/project.go
+++ b/internal/scaffold/forms/project.go
@@ -2,6 +2,7 @@ package forms
 
 import (
 	"github.com/erikgeiser/promptkit/textinput"
+	"github.com/rs/zerolog"
 	"github.com/snyk/cli-extension-cloud/internal/project"
 )
 
@@ -14,6 +15,7 @@ type (
 		Project     *project.Project
 		DefaultName string
 		Fields      ProjectFields
+		Logger      *zerolog.Logger
 	}
 )
 
@@ -26,6 +28,7 @@ func (p *ProjectForm) Run() error {
 	manifest.Name = p.Fields.Name
 
 	p.Project.UpdateManifest(manifest)
+	p.Logger.Info().Msgf("Initializing or updating project '%s'", p.Fields.Name)
 	return nil
 }
 

--- a/internal/scaffold/forms/relation.go
+++ b/internal/scaffold/forms/relation.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/erikgeiser/promptkit/confirmation"
 	"github.com/erikgeiser/promptkit/textinput"
+	"github.com/rs/zerolog"
 	"github.com/snyk/cli-extension-cloud/internal/project"
 )
 
@@ -20,6 +21,7 @@ type (
 	RelationForm struct {
 		Project *project.Project
 		Fields  RelationFields
+		Logger  *zerolog.Logger
 	}
 )
 
@@ -50,7 +52,12 @@ func (f *RelationForm) Run() error {
 	if err != nil {
 		return err
 	}
-	return f.Project.AddRelation(relation)
+	path, err := f.Project.AddRelation(relation)
+	if err != nil {
+		return err
+	}
+	f.Logger.Info().Msgf("Adding relation '%s' to %s", f.Fields.Name, path)
+	return nil
 }
 
 func (f *RelationForm) promptName() error {

--- a/internal/scaffold/project.go
+++ b/internal/scaffold/project.go
@@ -18,6 +18,7 @@ func ProjectWorkflow(
 	ictx workflow.InvocationContext,
 	_ []workflow.Data,
 ) ([]workflow.Data, error) {
+	logger := ictx.GetEnhancedLogger()
 	wd, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -33,6 +34,7 @@ func ProjectWorkflow(
 	form := &forms.ProjectForm{
 		Project:     proj,
 		DefaultName: defaultName,
+		Logger:      logger,
 	}
 	if err := form.Run(); err != nil {
 		return nil, err

--- a/internal/scaffold/relation.go
+++ b/internal/scaffold/relation.go
@@ -16,11 +16,15 @@ func RelationWorkflow(
 	ictx workflow.InvocationContext,
 	_ []workflow.Data,
 ) ([]workflow.Data, error) {
+	logger := ictx.GetEnhancedLogger()
 	proj, err := project.FromDir(afero.NewOsFs(), ".")
 	if err != nil {
 		return nil, err
 	}
-	form := &forms.RelationForm{Project: proj}
+	form := &forms.RelationForm{
+		Project: proj,
+		Logger:  logger,
+	}
 	if err := form.Run(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds some log messages to `iac scaffold project` and `iac scaffold relation` to be consistent with the other scaffold commands and to provide feedback about what the commands are doing.