### PR TITLE
fix: CLOUD-1372 AddRuleSpec called twice in cloudspec

### DIFF
--- a/internal/scaffold/forms/cloudspec.go
+++ b/internal/scaffold/forms/cloudspec.go
@@ -56,7 +56,6 @@ func (f *CloudSpecForm) Run() error {
 		return err
 	}
 	filename := addExtIfNeeded(f.Name, ".json")
-	f.Project.AddRuleSpec(f.RuleID, filename, b)
 	path, err := f.Project.AddRuleSpec(f.RuleID, filename, b)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR fixes a bug in the scaffold Cloud spec form where we'd attempt to add the spec twice. This resulted in an error on the second call, because the spec was already added.