### PR TITLE
feat: add repl command (CLOUD-1453)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/open-policy-agent/opa v0.51.0
 	github.com/rs/zerolog v1.29.1
 	github.com/snyk/go-application-framework v0.0.0-20230502084119-2f982ec5943d
-	github.com/snyk/policy-engine v0.21.1
+	github.com/snyk/policy-engine v0.22.0
 	github.com/spf13/afero v1.9.2
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
@@ -89,8 +89,10 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.13.0 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
+	github.com/peterh/liner v1.2.2 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect

--- a/go.sum
+++ b/go.sum
@@ -498,7 +498,9 @@ github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPn
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
+github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -527,12 +529,16 @@ github.com/muesli/termenv v0.11.1-0.20220204035834-5ac8409525e0/go.mod h1:Bd5NYQ
 github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
 github.com/muesli/termenv v0.13.0 h1:wK20DRpJdDX8b7Ek2QfhvqhRQFZ237RGRO0RQ/Iqdy0=
 github.com/muesli/termenv v0.13.0/go.mod h1:sP1+uffeLaEYpyOTb8pLCUctGcGLnoFjSn4YJK5e2bc=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/open-policy-agent/opa v0.51.0 h1:2hS5xhos8HtkN+mgpqMhNJSFtn/1n/h3wh+AeTPJg6Q=
 github.com/open-policy-agent/opa v0.51.0/go.mod h1:OjmwLfXdeR7skSxrt8Yd3ScXTqPxyJn7GeTRJrcEerU=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=
 github.com/pelletier/go-toml/v2 v2.0.5/go.mod h1:OMHamSCAODeSsVrwwvcJOaoN0LIUIaFVNZzmWyNfXas=
+github.com/peterh/liner v1.2.2 h1:aJ4AOodmL+JxOZZEL2u9iJf8omNRpqHc/EbrK+3mAXw=
+github.com/peterh/liner v1.2.2/go.mod h1:xFwJyiKIXJZUKItq5dGHZSTBRAuG/CpeNpWLyiNRNwI=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -565,8 +571,8 @@ github.com/snyk/go-application-framework v0.0.0-20230502084119-2f982ec5943d h1:h
 github.com/snyk/go-application-framework v0.0.0-20230502084119-2f982ec5943d/go.mod h1:QMdFROeuG06UULLD2hzN/P9RlKE6Ma6eskMwAqVOMkM=
 github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650 h1:CsLoEIHxq4i3d9di8RoN3J3D1/oK20oroEZUGShor0o=
 github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
-github.com/snyk/policy-engine v0.21.1 h1:bB/Z8iErHPDEa9MVQpnSWjr76OF+j8CclNktU6X4M3Y=
-github.com/snyk/policy-engine v0.21.1/go.mod h1:Vvy/9VMXoABS3JlLqhTlAPWkB5LgbLh7LGn3gBwAqdY=
+github.com/snyk/policy-engine v0.22.0 h1:od9pduGrXyfWO791X+8M1qmnvWUxaIXh0gBzGKqeseA=
+github.com/snyk/policy-engine v0.22.0/go.mod h1:Vvy/9VMXoABS3JlLqhTlAPWkB5LgbLh7LGn3gBwAqdY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=
 github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
@@ -825,6 +831,7 @@ golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/iacrules/iacrules.go
+++ b/iacrules/iacrules.go
@@ -19,6 +19,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/workflow"
 
 	"github.com/snyk/cli-extension-iac-rules/internal/push"
+	"github.com/snyk/cli-extension-iac-rules/internal/repl"
 	"github.com/snyk/cli-extension-iac-rules/internal/spec"
 )
 
@@ -30,6 +31,9 @@ func Init(e workflow.Engine) error {
 		return err
 	}
 	if err := push.RegisterWorkflows(e); err != nil {
+		return err
+	}
+	if err := repl.RegisterWorkflows(e); err != nil {
 		return err
 	}
 	return nil

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -209,17 +209,20 @@ func (p *Project) InputTypeForRule(ruleID string) (string, error) {
 	return inputType, nil
 }
 
-func (p *Project) Engine(ctx context.Context) (*engine.Engine, error) {
+func (p *Project) Providers() (providers []data.Provider) {
 	fsys := afero.NewIOFS(p.FS)
-	var providers []data.Provider
 	if p.libDir.Exists() {
 		providers = append(providers, data.FSProvider(fsys, p.libDir.Path()))
 	}
 	if p.rulesDir.Exists() {
 		providers = append(providers, data.FSProvider(fsys, p.rulesDir.Path()))
 	}
+	return
+}
+
+func (p *Project) Engine(ctx context.Context) (*engine.Engine, error) {
 	eng := engine.NewEngine(ctx, &engine.EngineOptions{
-		Providers: providers,
+		Providers: p.Providers(),
 	})
 	if len(eng.InitializationErrors) > 0 {
 		return nil, &multierror.Error{

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -1,0 +1,89 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/snyk/go-application-framework/pkg/workflow"
+	"github.com/snyk/policy-engine/pkg/rego/repl"
+	"github.com/spf13/afero"
+	"github.com/spf13/pflag"
+
+	"github.com/snyk/cli-extension-iac-rules/internal/project"
+	"github.com/snyk/cli-extension-iac-rules/internal/utils"
+)
+
+const (
+	flagInit  = "repl-init"
+	flagInput = "repl-input"
+)
+
+func RegisterWorkflows(e workflow.Engine) error {
+	workflowID := workflow.NewWorkflowIdentifier("iac.repl")
+
+	flagset := pflag.NewFlagSet("snyk-cli-extension-iac-repl", pflag.ExitOnError)
+	flagset.StringSlice(flagInit, []string{}, "Run commands on REPL initialization")
+	flagset.String(flagInput, "", "Input IaC file")
+
+	c := workflow.ConfigurationOptionsFromFlagset(flagset)
+	if _, err := e.Register(workflowID, c, replWorkflow); err != nil {
+		return fmt.Errorf("error while registering %s workflow: %w", workflowID, err)
+	}
+	return nil
+}
+
+func replWorkflow(
+	ictx workflow.InvocationContext,
+	_ []workflow.Data,
+) ([]workflow.Data, error) {
+	ctx := context.Background()
+	init := ictx.GetConfiguration().GetStringSlice(flagInit)
+	inputPath := ictx.GetConfiguration().GetString(flagInput)
+
+	fs := afero.NewOsFs()
+	prj, err := project.FromDir(fs, ".")
+	if err != nil {
+		return nil, err
+	}
+
+	input := map[string]interface{}{}
+	if inputPath != "" {
+		singleInput, err := utils.LoadSingleInput(inputPath)
+		if err != nil {
+			return nil, err
+		}
+		bytes, err := json.Marshal(singleInput.State)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(bytes, &input); err != nil {
+			return nil, err
+		}
+	}
+
+	err = repl.Repl(ctx, repl.Options{
+		Providers: prj.Providers(),
+		Init:      init,
+		Input:     input,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return []workflow.Data{}, nil
+}

--- a/internal/utils/cloud_scan_loader.go
+++ b/internal/utils/cloud_scan_loader.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package spec
+package utils
 
 import (
 	"encoding/json"

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,51 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+
+	"github.com/snyk/policy-engine/pkg/input"
+	"github.com/snyk/policy-engine/pkg/models"
+	"github.com/spf13/afero"
+)
+
+type SingleInput struct {
+	State  models.State
+	Loader input.Loader // Can be used to call AddSourceLocs
+}
+
+func LoadSingleInput(path string) (*SingleInput, error) {
+	detector, err := input.DetectorByInputTypes(input.Types{input.Auto})
+	if err != nil {
+		return nil, err
+	}
+	detector = input.NewMultiDetector(cloudScanDetector{}, detector)
+	loader := input.NewLoader(detector)
+	fsys := afero.OsFs{}
+	detectable, err := input.NewDetectable(fsys, path)
+	if err != nil {
+		return nil, err
+	}
+	_, err = loader.Load(detectable, input.DetectOptions{})
+	if err != nil {
+		return nil, err
+	}
+	states := loader.ToStates()
+	if len(states) != 1 {
+		return nil, fmt.Errorf("internal error: expected a single input but got %d", len(states))
+	}
+	return &SingleInput{State: states[0], Loader: loader}, nil
+}


### PR DESCRIPTION
This adds the `snyk iac repl` command which loads up the current project in a REPL.

`--repl-input` provides a way to set the input to a specific IaC file or directory, e.g.:

    cloud-custom-rules-demo$ snyk iac repl \
      --repl-input spec/rules/DEMO_001/inputs/infra.tf

`--repl-init` lets you run commands when the repl is initialized, which can be helpful to set up the dev environment, e.g. load the rule you are developing:

    cloud-custom-rules-demo$ snyk iac repl \
      --repl-input spec/rules/DEMO_001/inputs/infra.tf \
      --repl-init 'package rules.DEMO_001'
      
Initializing the repl like that lets you "just" evaluate rules like `deny` or `resources`.