### PR TITLE
fix: panic in relation form from nil logger

### DIFF
--- a/internal/scaffold/forms/multiresource.go
+++ b/internal/scaffold/forms/multiresource.go
@@ -156,6 +156,7 @@ func (f *MultiResourceRuleForm) promptRelation() error {
 	case addNewRelation:
 		form := &RelationForm{
 			Project: f.Project,
+			Logger:  f.Logger,
 			Fields: RelationFields{
 				PrimaryResourceType:   f.Fields.PrimaryResourceType,
 				SecondaryResourceType: f.Fields.SecondaryResourceType,


### PR DESCRIPTION
This PR fixes a panic in the relation form. The cause of the panic was that the logger wasn't getting set in the relation form when it was invoked by the multi-resource rule form.