### PR TITLE
feat: infer input types from product in iac scaffold rule

### DIFF
--- a/internal/scaffold/forms/common.go
+++ b/internal/scaffold/forms/common.go
@@ -20,10 +20,19 @@ type Form interface {
 	Run() error
 }
 
-func inputTypes() []string {
+func allInputTypes() []string {
 	return []string{
 		input.Terraform.Name,
 		input.CloudScan.Name,
+		input.Kubernetes.Name,
+		input.CloudFormation.Name,
+		input.Arm.Name,
+	}
+}
+
+func iacInputTypes() []string {
+	return []string{
+		input.Terraform.Name,
 		input.Kubernetes.Name,
 		input.CloudFormation.Name,
 		input.Arm.Name,

--- a/internal/scaffold/forms/rule.go
+++ b/internal/scaffold/forms/rule.go
@@ -20,6 +20,7 @@ import (
 	"github.com/erikgeiser/promptkit/textinput"
 	"github.com/rs/zerolog"
 	"github.com/snyk/cli-extension-iac-rules/internal/project"
+	"github.com/snyk/policy-engine/pkg/input"
 )
 
 type (
@@ -162,14 +163,15 @@ func (f *RuleForm) promptProduct() error {
 		return err
 	}
 
-	var products []string
 	switch choice {
-	case "iac", "cloud":
-		products = []string{choice}
+	case "iac":
+		f.Fields.Product = []string{choice}
+	case "cloud":
+		f.Fields.Product = []string{choice}
+		f.Fields.InputType = input.CloudScan.Name
 	case "both":
-		products = []string{"iac", "cloud"}
+		f.Fields.Product = []string{"iac", "cloud"}
 	}
-	f.Fields.Product = products
 	return nil
 }
 
@@ -178,7 +180,11 @@ func (f *RuleForm) promptInputType() error {
 		return nil
 	}
 
-	prompt := selection.New("Input type:", inputTypes())
+	choices := allInputTypes()
+	if len(f.Fields.Product) == 1 && f.Fields.Product[0] == "iac" {
+		choices = iacInputTypes()
+	}
+	prompt := selection.New("Input type:", choices)
 	inputType, err := prompt.RunPrompt()
 	if err != nil {
 		return err

--- a/internal/scaffold/forms/spec.go
+++ b/internal/scaffold/forms/spec.go
@@ -132,13 +132,13 @@ func (f *SpecForm) promptInputType() error {
 	defaultInputType, err := f.Project.InputTypeForRule(f.Fields.RuleID)
 	if err == nil && defaultInputType != "" {
 		choices = []string{defaultInputType}
-		for _, t := range inputTypes() {
+		for _, t := range allInputTypes() {
 			if t != defaultInputType {
 				choices = append(choices, t)
 			}
 		}
 	} else {
-		choices = inputTypes()
+		choices = allInputTypes()
 	}
 	prompt := selection.New("Input type:", choices)
 	choice, err := prompt.RunPrompt()


### PR DESCRIPTION
This PR changes the rule form to infer the rule's input type from the product. When the `cloud` product is selected, the input type is inferred to be `cloud_scan`. When only `iac` is selected, the list is limited to the IaC input types.

We might be able to infer that if a user selects both products then the input type should be `tf`. But, I'm worried that new users will be surprised by that behavior. I'll leave that for a future change.