### PR TITLE
[CTX-565] chore: add gitleaks pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.16.1
+    hooks:
+      - id: gitleaks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,3 +3,21 @@
 This repo is intended for internal (Snyk) contributions only at this time.
 
 Please [reach our support](SUPPORT.md) to give any feedback.
+
+## Local setup
+
+Please use the `pre-commit` to automatically run tools on specific Git hooks. To do so:
+
+For macos & brew users: 
+
+```bash
+brew install pre-commit
+```
+
+Or make sure you have pre-commit available on your PATH before running the command below.
+
+```bash
+pre-commit install
+```
+
+Read the [pre-commit configuration](.pre-commit-config.yaml) to check the set-up.


### PR DESCRIPTION
Based on https://snyksec.atlassian.net/browse/CTX-565, we want to implement ProdSec secret scanning process: https://github.com/snyk/prodsec-docs/blob/main/docs/service_catalogue/secrets_scanning_process.md. 

Starting with pre-commit hook