### PR TITLE
chore: remove license notice from template files

### DIFF
--- a/internal/init/forms/spectemplates/cfn.yaml
+++ b/internal/init/forms/spectemplates/cfn.yaml
@@ -1,17 +1,3 @@
-# © 2023 Snyk Limited All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   Valid:

--- a/internal/init/forms/spectemplates/infra.tf
+++ b/internal/init/forms/spectemplates/infra.tf
@@ -1,17 +1,3 @@
-# © 2023 Snyk Limited All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 provider "" {
 
 }

--- a/internal/init/forms/spectemplates/k8s.yaml
+++ b/internal/init/forms/spectemplates/k8s.yaml
@@ -1,17 +1,3 @@
-# © 2023 Snyk Limited All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 ---
 apiVersion: ""
 kind: ""


### PR DESCRIPTION
these are the template files that are used by `iac rules init`, it doesn't make sense to add the copyright and license notices to those files given that we expect customers to then change them.