### PR TITLE
[CTX-604] fix: return error when specs fail

### DIFF
--- a/cmd/develop/main.go
+++ b/cmd/develop/main.go
@@ -26,6 +26,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	cmd.SilenceUsage = true
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION


**fix: return error when specs fail**

The rule-testing functionality here runs "specs" (snapshot tests derived
automatically from a user-provided fixture), and then custom rego tests.
The latter uses policy-engine/test.

This commit fixes a bug in which only failing custom rego tests would
cause an error to be returned, and so the CLI would exit with zero even
when specs failed. More stderr output is added to make clear to the user
that 2 classes of test are running, which also helps contextualize the
"no test cases found" message from policy-engine.



---

@jaspervdj-snyk would you mind giving an opinion on whether this fix for the bug https://snyksec.atlassian.net/browse/CTX-604 is valid? I've not really been in this area before 🙏 

Running failing and passing tests using the develop binary seems to work appropriately with this PR, but I haven't tested the integration with the main CLI yet - I'm not sure how to actually do that with a custom build.