### PR TITLE
[CTX-600] fix: return non-JSON errors to the user

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -121,7 +121,11 @@ func parseResponse(rsp *http.Response, expectedStatusCode int, expectedDocument 
 	if rsp.StatusCode != expectedStatusCode {
 		var errorDoc errorDocument
 		if err := json.Unmarshal(body, &errorDoc); err != nil {
-			return fmt.Errorf("response %d: %s", rsp.StatusCode, err)
+			// If the error is not encoded as JSON, that is less important a detail to
+			// surface to the user than the actual content of the error. Notably, this
+			// can occur when cerberus bounces the request, as it returns plain text
+			// bodies.
+			return fmt.Errorf("response %d: %s", rsp.StatusCode, string(body))
 		}
 		return fmt.Errorf("%s", errorDocumentToString(errorDoc))
 	}


### PR DESCRIPTION
They are more important to surface than the fact that we can't parse them as JSON.

---

I wonder if it would be more in the spirit of https://snyksec.atlassian.net/browse/CTX-600 to add some logic for various response codes and give a more specific error message. For example, a 403 could result in an error message like "org $ORG_ID is forbidden from pushing custom rules". I wonder if that is too speculative though, which is why I hesitated. Feedback welcome!