### PR TITLE
[CTX-613] chore: move ownership from cloud context to IaC+

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/cloud-context
+* @snyk/cloud-dev-ex


### PR DESCRIPTION
As part of the Cloud Group consolidation, this repository's Cloud Context
ownership is moving to the IaC+ team.
